### PR TITLE
Fix wrong payment code

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="26d7345f-504d-4191-a249-f4e16bf92127" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/Model/PaymentMethod/Filter/AdyenConfigured.php" beforeDir="false" afterPath="$PROJECT_DIR$/Model/PaymentMethod/Filter/AdyenConfigured.php" afterDir="false" />
+    </list>
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="ComposerSettings" synchronizationState="SYNCHRONIZE">
+    <pharConfigPath>$PROJECT_DIR$/composer.json</pharConfigPath>
+    <execution />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="PhpWorkspaceProjectConfiguration" interpreter_name="PHP_8.1" />
+  <component name="ProjectColorInfo">{
+  &quot;associatedIndex&quot;: 4
+}</component>
+  <component name="ProjectId" id="30XH9zqZ3XYCVEeBnnuqtsX1ULq" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "ModuleVcsDetector.initialDetectionPerformed": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.git.unshallow": "true",
+    "git-widget-placeholder": "fix-wrong-payment-code",
+    "junie.onboarding.icon.badge.shown": "true",
+    "last_opened_file_path": "/Volumes/workspace/adyen-magento2-hyva",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "vue.rearranger.settings.migration": "true"
+  }
+}]]></component>
+  <component name="SharedIndexes">
+    <attachedChunks>
+      <set>
+        <option value="bundled-js-predefined-d6986cc7102b-09060db00ec0-JavaScript-PS-251.26927.60" />
+        <option value="bundled-php-predefined-a98d8de5180a-e5747d4f5a45-com.jetbrains.php.sharedIndexes-PS-251.26927.60" />
+      </set>
+    </attachedChunks>
+  </component>
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="26d7345f-504d-4191-a249-f4e16bf92127" name="Changes" comment="" />
+      <created>1753766850012</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1753766850012</updated>
+      <workItem from="1753766851549" duration="1602000" />
+    </task>
+    <servers />
+  </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
+</project>

--- a/Model/PaymentMethod/Filter/AdyenConfigured.php
+++ b/Model/PaymentMethod/Filter/AdyenConfigured.php
@@ -74,7 +74,7 @@ class AdyenConfigured implements FilterInterface
     private function collectMethodCodeWithoutPrefix($methodCode): string
     {
         if ($methodCode == CreditCard::METHOD_CC) {
-            return 'card';
+            return 'scheme';
         }
 
         return substr(

--- a/view/frontend/templates/payment/model/adyen-payment-method.phtml
+++ b/view/frontend/templates/payment/model/adyen-payment-method.phtml
@@ -316,7 +316,9 @@ $billingAddress = $block->getQuoteBillingAddress();
                 countryCode: formattedShippingAddress.country_id ? formattedShippingAddress.country_id : formattedBillingAddress.country_id
             };
 
-            if (!!paymentMethodsExtraInfo[paymentMethod.type].configuration) {
+            if (paymentMethodsExtraInfo &&
+                paymentMethodsExtraInfo[paymentMethod.type] &&
+                paymentMethodsExtraInfo[paymentMethod.type].configuration) {
                 return Object.assign(configuration, paymentMethodsExtraInfo[paymentMethod.type].configuration)
             } else {
                 return configuration;


### PR DESCRIPTION
### Merge Request Description

#### Issue Description
This merge request addresses an issue in the Adyen payment method filtering for Hyvä Checkout. In the original implementation, the credit card payment method (`adyen_cc`) was incorrectly mapped to "card" when checking against available payment methods from Adyen's API. However, Adyen's API expects this payment method to be identified as "scheme" rather than "card".

#### Fix Implementation
The fix changes the return value in the `collectMethodCodeWithoutPrefix` method from "card" to "scheme" when handling the credit card payment method. This ensures proper mapping between Magento's payment method codes and Adyen's API expectations.

```diff
private function collectMethodCodeWithoutPrefix($methodCode): string
{
    if ($methodCode == CreditCard::METHOD_CC) {
-        return 'card';
+        return "scheme";
    }

    return substr(
        $methodCode,
        strpos($methodCode, ProcessingMetadataInterface::METHOD_ADYEN_PREFIX) + 
        strlen(ProcessingMetadataInterface::METHOD_ADYEN_PREFIX)
    );
}
```

#### Steps to Reproduce the Issue
1. Configure Adyen payment methods in Magento admin
2. Navigate to checkout with Hyvä Checkout enabled
3. Observe that credit card payment method is not available, despite being configured in Adyen

#### Expected Behavior
Credit card payment method should be available at checkout when properly configured in Adyen.

#### Root Cause
The mismatch between the identifier used in the code ("card") and the one expected by Adyen's API ("scheme") caused the credit card payment method to be incorrectly filtered out, even when it was properly configured.

This fix ensures that the correct identifier is used when checking if the credit card payment method is available according to Adyen's configuration.